### PR TITLE
chore: remove eslint's capitalized-comments rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,7 +43,6 @@
         "allowSingleLine": true
       }
     ],
-    "capitalized-comments": "warn",
     "comma-dangle": [
       "warn",
       "always-multiline"

--- a/src/store/training/actions/index.js
+++ b/src/store/training/actions/index.js
@@ -37,8 +37,8 @@ export default {
     } catch (error) {
       console.log(error);
 
-      // Commit("loginFailure", error);
-      // Dispatch("alert/error", error, { root: true });
+      // commit("loginFailure", error);
+      // dispatch("alert/error", error, { root: true });
     }
   },
 };


### PR DESCRIPTION
It makes commenting out code cumbersome.